### PR TITLE
Parallelize Trace table purge

### DIFF
--- a/src/main/java/org/usf/inspect/server/PurgeScheduler.java
+++ b/src/main/java/org/usf/inspect/server/PurgeScheduler.java
@@ -19,6 +19,6 @@ public class PurgeScheduler {
     @TraceableStage
     @Scheduled(cron= "${inspect.server.purge.schedule:0 0 1 * * ?}")
     public void purge() {
-        purgeService.purge();
+        purgeService.launchPurge();
     }
 }

--- a/src/main/java/org/usf/inspect/server/controller/PurgeController.java
+++ b/src/main/java/org/usf/inspect/server/controller/PurgeController.java
@@ -18,17 +18,8 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 public class PurgeController {
     private final PurgeService purgeService;
 
-    @DeleteMapping("{env}")
-    public void purge(
-            @PathVariable(name = "env") String env,
-            @RequestParam(name = "apps", required = false) List<String> apps,
-            @RequestParam(name = "date_limit") Instant dateLimit
-    ){
-        purgeService.purge(env, apps, dateLimit);
-    }
-
     @DeleteMapping("batch")
     public void purge(){
-        purgeService.purge();
+        purgeService.launchPurge();
     }
 }

--- a/src/main/java/org/usf/inspect/server/service/PurgeService.java
+++ b/src/main/java/org/usf/inspect/server/service/PurgeService.java
@@ -6,80 +6,122 @@ import org.springframework.stereotype.Service;
 import org.usf.inspect.core.InstanceEnvironment;
 import org.usf.inspect.server.dao.PurgeDao;
 
-import java.time.Instant;
-import java.util.List;
-import java.util.stream.IntStream;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
+import static java.sql.Timestamp.*;
 import static java.time.LocalDate.now;
 import static java.time.ZoneId.systemDefault;
-import static java.util.Objects.isNull;
+import static java.util.concurrent.CompletableFuture.*;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.stream.Collectors.*;
+import static org.usf.inspect.core.ExecutorServiceWrapper.*;
+import static org.usf.inspect.core.RequestMask.*;
 import static org.usf.inspect.core.SessionContextManager.emitInfo;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class PurgeService {
+
+    private final ExecutorService technicalExecutor = wrap(newFixedThreadPool(5));
+    private final ExecutorService functionalExecutor = wrap(newFixedThreadPool(5));
+
     private final PurgeDao purgeDao;
 
-    private interface PurgeStrategy {
-        void execute();
-    }
-
-    private class BatchPurgeStrategy implements PurgeStrategy {
-        @Override
-        public void execute() {
-            var now = now().atStartOfDay().atZone(systemDefault()).toInstant();
-            var instances = purgeDao.getInstances(null);
-            for (InstanceEnvironment instance : instances) {
-                Instant dateLimit = now.minus(instance.getConfiguration().getTracing().getRemote().getRetentionMaxAge());
-                var deleted = purgeDao.purgeByInstance(dateLimit, instance.getEnv(), instance.getName());
-                log.info("------ Purge complete ------ [{}]:[{}] — [{}] rows deleted before [{}]", instance.getEnv(), instance.getName(), IntStream.of(deleted).sum(), dateLimit);
-                emitInfo("Purge completed for instance [" + instance.getEnv() + "]:[" + instance.getName() + "] — [" + IntStream.of(deleted).sum() + "] rows deleted before [" + dateLimit + "]");
-            }
-        }
-    }
-
-    private class TargetedPurgeStrategy implements PurgeStrategy {
-        private final String env;
-        private final List<String> apps;
-        private final Instant dateLimit;
-
-        public TargetedPurgeStrategy(String env, List<String> apps, Instant dateLimit) {
-            this.env = env;
-            this.apps = apps;
-            this.dateLimit = dateLimit;
-        }
-
-        @Override
-        public void execute() {
-            for (String app : apps) {
-                var deleted = purgeDao.purgeByInstance(dateLimit, env, app);
-                log.info("------ Purge complete ------ [{}]:[{}] — [{}] rows deleted before [{}]", env, app, IntStream.of(deleted).sum(), dateLimit);
-                emitInfo("Purge completed for instance [" + env + "]:[" + app + "] — [" + IntStream.of(deleted).sum() + "] rows deleted before [" + dateLimit + "]");
-            }
-        }
-    }
-
-    private void performPurge(PurgeStrategy strategy) {
+    public void launchPurge() {
         log.info("------ Purge start ------");
         try {
-            log.info("------ Purge execute ------");
-            strategy.execute();
-        } finally {
-            var deleted = purgeDao.finalizePurge();
-            log.info("------ Purge finally ------ [{}] rows deleted", IntStream.of(deleted).sum());
-            emitInfo("Purge finally — [" + IntStream.of(deleted).sum() + "] rows deleted");
+            var now = now().atStartOfDay().atZone(systemDefault()).toInstant();
+            var instances = purgeDao.getInstances();
+            log.info("------ Purge ------ method=selected, label=Instance, rows={}", instances.size());
+            emitInfo("method=select, label=Instance, rows=" + instances.size());
+            var tasks = new ArrayList<CompletableFuture<Void>>(instances.size());
+            for (InstanceEnvironment instance : instances) {
+                Timestamp dateLimit = from(now.minus(instance.getConfiguration().getTracing().getRemote().getRetentionMaxAge()));
+                var ids = purgeDao.selectInstanceIds(dateLimit, instance.getEnv(), instance.getName(), instance.getType());
+                log.info("------ Purge ------ method=selected, label=InstanceId, rows={}, app={}, env={}, date={}", ids.size(), instance.getName(), instance.getEnv(), dateLimit);
+                emitInfo("method=select, label=InstanceId, rows=" + ids.size() + ", app=" + instance.getName() + ", env=" + instance.getEnv() + ", date=" + dateLimit);
+                tasks.add(runAsync(runnablePurge(() -> purgeDao.purgeInstance(instance.getEnv(), instance.getName(), dateLimit), "Instance", instance.getEnv(), instance.getName(), dateLimit),  functionalExecutor));
+                if(!ids.isEmpty()) {
+                    var stringIds = ids.stream().collect(joining("','", "'", "'"));
+                    tasks.add(purge(stringIds, dateLimit, instance.getEnv(), instance.getName()));
+                }
+            }
+            allOf(tasks.toArray(new CompletableFuture[0])).join();
+        }
+        finally {
+            log.info("------ Purge finally ------");
+            purge().join();
             log.info("------ Purge vacuum ------");
             purgeDao.vacuumAnalyze();
         }
         log.info("------ Purge end ------");
     }
 
-    public void purge() {
-        performPurge(new BatchPurgeStrategy());
+    public CompletableFuture<Void> purge(String ids, Timestamp dateLimit, String env, String app) {
+        return allOf(
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("ins_trc", ids, dateLimit, false), "InstanceTrace", app, env, dateLimit), technicalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("rsc_usg", ids, dateLimit, false), "ResourceUsage", app, env, dateLimit), technicalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeSessionStage("rst_ses", "rst_ses_stg", ids, dateLimit), "RestSession", app, env, dateLimit), technicalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeRequest("rst_ses", ids, dateLimit, true), "RestSessionStage", app, env, dateLimit), functionalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequestStage("rst_rqt", "rst_rqt_stg", REST.name(), ids, dateLimit), "RestRequest", app, env, dateLimit), technicalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeRequest("rst_rqt", ids, dateLimit, true), "RestRequestStage", app, env, dateLimit), functionalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequestStage("smtp_rqt", "smtp_stg", SMTP.name(), ids, dateLimit), "SmtpRequest", app, env, dateLimit), technicalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeRequest("smtp_rqt", ids, dateLimit, true), "SmtpRequestStage", app, env, dateLimit), functionalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequestStage("ftp_rqt", "ftp_stg", FTP.name(), ids, dateLimit), "FtpRequest", app, env, dateLimit), technicalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeRequest("ftp_rqt", ids, dateLimit, true), "FtpRequestStage", app, env, dateLimit), functionalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequestStage("ldap_rqt", "ldap_stg", LDAP.name(), ids, dateLimit), "LdapRequest", app, env, dateLimit), technicalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeRequest("ldap_rqt", ids, dateLimit, true), "LdapRequestStage", app, env, dateLimit), functionalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequestStage("dtb_rqt", "dtb_stg", JDBC.name(), ids, dateLimit), "JdbcRequest", app, env, dateLimit), technicalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeRequest("dtb_rqt", ids, dateLimit, true), "JdbcRequestStage", app, env, dateLimit), functionalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("lcl_rqt", ids, dateLimit, true), "LclRequestStage", app, env, dateLimit), functionalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("main_ses", ids, dateLimit, true), "MainSession", app, env, dateLimit), functionalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("log_ent", ids, dateLimit, false), "LogEntry", app, env, dateLimit), functionalExecutor)
+        );
     }
 
-    public void purge(String env, List<String> apps, Instant dateLimit) {
-        performPurge(new TargetedPurgeStrategy(env, isNull(apps) || apps.isEmpty() ? purgeDao.getInstances(env).stream().map(InstanceEnvironment::getName).toList() : apps, dateLimit));
+    public CompletableFuture<Void> purge() {
+        return allOf(
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("log_ent"), "LogEntry"), functionalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("lcl_rqt"), "LocalRequest"), functionalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("main_ses"), "MainSession"), functionalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeSessionStage("usr_acn", "main_ses"), "UserAction"), functionalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("rst_ses"), "RestSession"), functionalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeSessionStage("rst_ses_stg", "rst_ses"), "RestSessionStage"), technicalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("rst_rqt"), "RestRequest"), functionalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeRequestStage("rst_rqt_stg", "rst_rqt", REST.name()), "RestRequestStage"), technicalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("smtp_rqt"), "SmtpRequest"), functionalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeRequestStage("smtp_stg", "smtp_rqt", SMTP.name()), "SmtpRequestStage"), technicalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("ftp_rqt"), "FtpRequest"), functionalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeRequestStage("ftp_stg", "ftp_rqt", FTP.name()), "FtpRequestStage"), technicalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("ldap_rqt"), "LdapRequest"), functionalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeRequestStage("ldap_stg", "ldap_rqt", LDAP.name()), "LdapRequestStage"), technicalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("dtb_rqt"), "JdbcRequest"), functionalExecutor)
+                        .thenRunAsync(runnablePurge(() -> purgeDao.purgeRequestStage("dtb_stg", "dtb_rqt", JDBC.name()), "JdbcRequestStage"), technicalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("ins_trc"), "InstanceTrace"), technicalExecutor),
+                runAsync(runnablePurge(() -> purgeDao.purgeRequest("rsc_usg"), "ResourceUsage"), technicalExecutor)
+        );
+    }
+
+    private Runnable runnablePurge(Supplier<Integer> action, String label, String app, String env, Timestamp dateLimit) {
+        return () -> {
+            var sum = action.get();
+            if (dateLimit != null) {
+                log.info("------ Purge ------ method=delete, label={}, rows={}, app={}, env={}, date={}", label, sum, app, env, dateLimit);
+                emitInfo("method=delete, label=" + label + ", rows=" + sum + ", app=" + app + ", env=" + env + ", date=" + dateLimit);
+            }
+            else {
+                log.info("------ Purge ------ method=delete, label={}, rows={}", label, sum);
+                emitInfo("method=delete, label=" + label + ", rows=" + sum);
+            }
+        };
+    }
+
+    private Runnable runnablePurge(Supplier<Integer> action, String label) {
+        return runnablePurge(action, label, null, null, null);
     }
 }


### PR DESCRIPTION
## Summary of Changes in PR #309: Parallelize Trace table purge

This pull request introduces **parallel processing for the trace table purge operation** using thread pools and CompletableFutures. Here's a breakdown of the changes across 4 modified files:

### **1. PurgeScheduler.java** (1 line changed)
- Updated the scheduled purge method to call `launchPurge()` instead of `purge()`

### **2. PurgeController.java** (11 lines changed)
- **Removed** the endpoint `@DeleteMapping("{env}")` that accepted environment-specific, application-specific, and date-limited purge requests
- **Kept only** the `@DeleteMapping("batch")` endpoint which now calls `launchPurge()`
- This simplifies the API to support only batch purge operations

### **3. PurgeDao.java** (156 lines changed - 80 additions, 76 deletions)
- **Removed** hardcoded SQL query templates (DELETE_BY_INSTANCE, DELETE_BY_INSTANCE_WITHOUT_END, etc.)
- **Removed** instance filtering logic from `getInstances()` method - now retrieves ALL instances instead of filtering by environment
- **Added new methods** for granular purge operations:
  - `purgeRequest(tableSuffix, ids, dateLimit, withEnd)` - deletes records from a specific table
  - `purgeRequest(tableSuffix)` - cleanup for orphaned records
  - `purgeRequestStage()` - new methods for handling stage/exception tables
  - `purgeSessionStage()` - specialized cleanup for session stage data
  - `purgeInstance()` - cleanup instance records
- **Modified** `selectInstanceIds()` to accept `InstanceType` parameter and changed method visibility from private to public

### **4. PurgeService.java** (146 lines changed - 94 additions, 52 deletions)
- **Removed** the Strategy pattern implementation (BatchPurgeStrategy and TargetedPurgeStrategy classes)
- **Removed** the targeted purge method `purge(String env, List<String> apps, Instant dateLimit)`
- **Added** two thread pool executors:
  - `technicalExecutor` - for technical/trace operations
  - `functionalExecutor` - for functional/session operations
- **Refactored purge logic** to use `CompletableFuture` for parallel execution:
  - `launchPurge()` - new main entry point that processes all instances in parallel
  - `purge(String ids, Timestamp dateLimit, String env, String app)` - now returns a CompletableFuture and executes multiple table deletions in parallel
  - `purge()` - cleanup method that also returns CompletableFuture for parallel finalization
- **Improved logging** with more granular method=select/delete labels for better monitoring

### **Key Architectural Changes:**
- **Parallelization**: Operations are now executed concurrently using multiple thread pools instead of sequential processing
- **Simplified API**: Removed targeted purge endpoint, keeping only batch operations
- **Better modularity**: Granular DAO methods allow independent parallel execution of different table purges
- **Enhanced observability**: More detailed logging with operation type and execution metrics