### PR TITLE
Refactor partition building logic into helper methods

### DIFF
--- a/src/main/java/org/usf/inspect/server/config/TraceApiColumn.java
+++ b/src/main/java/org/usf/inspect/server/config/TraceApiColumn.java
@@ -70,6 +70,8 @@ public enum TraceApiColumn implements ColumnDecorator {
     DB_VERSION("dbVersion"),
     COMMAND("command"),
     ACTION_COUNT("actionCount"),
+    ERROR_TYPE_SESSION("errorTypeSession", FilterConstant::errorTypeExpressionsSession),
+
     ARG("arg"),
     PARENT("parent"){
         @Override

--- a/src/main/java/org/usf/inspect/server/config/constant/FilterConstant.java
+++ b/src/main/java/org/usf/inspect/server/config/constant/FilterConstant.java
@@ -9,8 +9,7 @@ import static org.usf.inspect.server.config.TraceApiColumn.SIZE_IN;
 import static org.usf.inspect.server.config.TraceApiColumn.SIZE_OUT;
 import static org.usf.inspect.server.config.TraceApiColumn.START;
 import static org.usf.inspect.server.config.TraceApiColumn.STATUS;
-import static org.usf.inspect.server.config.TraceApiTable.EXCEPTION;
-import static org.usf.inspect.server.config.TraceApiTable.REST_REQUEST;
+import static org.usf.inspect.server.config.TraceApiTable.*;
 import static org.usf.jquery.core.ComparisonExpression.eq;
 import static org.usf.jquery.core.ComparisonExpression.ge;
 import static org.usf.jquery.core.ComparisonExpression.isNotNull;
@@ -171,6 +170,15 @@ public class FilterConstant {
                 .when(ge(200).and(lt(400)), null)
                 .when(ge(400).and(lt(500)), "ClientError")
                 .when(ge(500), "ServerError")
+                .end();
+    }
+
+    public static DBColumn errorTypeExpressionsSession(ViewDecorator table, String... args) {
+        var status = table.column(STATUS);
+        return status.toCase()
+                .when(ge(200).and(lt(400)), null)
+                .when(ge(400).and(lt(500)), "ClientError")
+                .when(ge(500), REST_SESSION.column(ERR_TYPE))
                 .end();
     }
 


### PR DESCRIPTION
This pull request introduces a new method for handling error type classification specific to session-based REST APIs and integrates it into the column definitions. It also makes a minor import simplification.

**Error type handling improvements:**

* Added the `ERROR_TYPE_SESSION` column to `TraceApiColumn`, which uses a new method to classify error types for session-based REST APIs.
* Implemented the `errorTypeExpressionsSession` method in `FilterConstant`, which maps HTTP status codes to error types, returning `null` for 2xx/3xx, `"ClientError"` for 4xx, and the error type from the session table for 5xx and above.

**Code cleanup:**

* Simplified imports in `FilterConstant.java` by using a wildcard import for `TraceApiTable`.